### PR TITLE
Simplify conditions repl.

### DIFF
--- a/obs_img_utils/cli.py
+++ b/obs_img_utils/cli.py
@@ -182,7 +182,7 @@ def download(
 
     image_conditions = []
     if add_conditions:
-        image_conditions = conditions_repl()
+        image_conditions = conditions_repl(config_data.no_color)
 
     with handle_errors(config_data.log_level, config_data.no_color):
         downloader = OBSImageUtil(

--- a/obs_img_utils/utils.py
+++ b/obs_img_utils/utils.py
@@ -146,60 +146,59 @@ def echo_style(message, no_color, fg='green'):
         click.secho(message, fg=fg)
 
 
-def conditions_repl():
+def conditions_repl(no_color):
     """
-    Query and accept input for image condition options.
+    Query and accept input for condition options.
     """
     image_conditions = []
     while True:
-        if click.confirm('Add an image condition?'):
-            condition_type = click.prompt(
-                'Enter the condition type',
-                type=click.Choice(['image', 'package'])
+        if click.confirm('Add a condition?'):
+            package_name = click.prompt(
+                'Enter the package name '
+                '(leave blank for an image condition)',
+                type=str,
+                default=''
             )
 
-            if condition_type == 'image':
-                image_version = click.prompt(
-                    'Enter the image version condition',
-                    type=str
+            condition_exp = click.prompt(
+                'Enter the condition expression',
+                type=click.Choice(['>=', '<=', '==', '>', '<']),
+                default='>='
+            )
+
+            version = click.prompt(
+                'Enter the version (optional)',
+                type=str,
+                default=''
+            )
+
+            release = click.prompt(
+                'Enter the release (optional)',
+                type=str,
+                default=''
+            )
+
+            if not (package_name or version or release):
+                echo_style(
+                    'Condition skipped, conditions require at least one of:'
+                    ' package_name, version or release.',
+                    no_color,
+                    fg='red'
                 )
+                continue
 
-                image_conditions.append({'image': image_version})
-            else:
-                package_name = click.prompt(
-                    'Enter the package name',
-                    type=str
-                )
+            condition = {
+                'condition': condition_exp,
+            }
 
-                condition_exp = click.prompt(
-                    'Enter the condition expression',
-                    type=click.Choice(['>=', '<=', '==', '>', '<']),
-                    default='>='
-                )
+            if package_name:
+                condition['package_name'] = package_name
+            if version:
+                condition['version'] = version
+            if release:
+                condition['release'] = release
 
-                version = click.prompt(
-                    'Enter the version (optional)',
-                    type=str,
-                    default=''
-                )
-
-                release = click.prompt(
-                    'Enter the release (optional)',
-                    type=str,
-                    default=''
-                )
-
-                condition = {
-                    'package_name': package_name,
-                    'condition': condition_exp,
-                }
-
-                if version:
-                    condition['version'] = version
-                elif release:
-                    condition['release'] = release
-
-                image_conditions.append(condition)
+            image_conditions.append(condition)
         else:
             break
 

--- a/tests/test_obs_img_utils_cli.py
+++ b/tests/test_obs_img_utils_cli.py
@@ -161,10 +161,11 @@ def test_image_download(
             '--target-dir', 'tests/data/', '--add-conditions'
         ],
         input='y\n'
-              'image\n'
+              '\n'
+              '==\n'
               '1.0.0\n'
+              '\n'
               'y\n'
-              'package\n'
               'apparmor-parser\n'
               '\n'
               '2.12.2\n'
@@ -215,12 +216,15 @@ def test_image_download_failed_conditions(
             '--conditions-wait-time', '1'
         ],
         input='y\n'
-              'image\n'
+              '\n'
+              '==\n'
               '1.1.0\n'
+              '\n'
               'n\n'
     )
 
     assert result.exit_code == 1
-    assert 'Image version condition failed:  1.0.0 == 1.1.0' in result.output
+    assert 'Version condition failed: ' \
+           'openSUSE-Leap-15.0-Azure 1.0.0 == 1.1.0' in result.output
     assert 'ImageConditionsException: Image conditions not met' \
         in result.output


### PR DESCRIPTION
If package name is left empty the conditions will apply to the image. Now an image version and release can be compared with the same set of evaluation expressions.