### PR TITLE
Handle new checksum format from build service.

### DIFF
--- a/obs_img_utils/utils.py
+++ b/obs_img_utils/utils.py
@@ -322,6 +322,10 @@ def get_checksum_from_file(checksum_file):
     """
     with open(checksum_file, 'r') as f:
         lines = f.readlines()
+
+    try:
         expected_checksum = lines[3].strip().split()[0]
+    except IndexError:
+        expected_checksum = lines[0].strip().split()[0]
 
     return expected_checksum


### PR DESCRIPTION
The signature is now split out in a separate file and the checksum is on the first line.

Also, handle the old format as well.