### PR TITLE
Add disallow license/package options.

### DIFF
--- a/obs_img_utils/api.py
+++ b/obs_img_utils/api.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import hashlib
+import fnmatch
 import logging
 import os
 import re
@@ -51,7 +52,7 @@ kiwi_version_match = r'(\d+\.\d+\.\d+)'
 
 package_type = namedtuple(
     'package_type', [
-        'version', 'release', 'arch', 'checksum'
+        'version', 'release', 'arch', 'license', 'checksum'
     ]
 )
 
@@ -79,7 +80,9 @@ class OBSImageUtil(object):
         log_callback=None,
         report_callback=None,
         checksum_extension=None,
-        extension=None
+        extension=None,
+        filter_licenses=None,
+        filter_packages=None
     ):
         if log_callback:
             self.log_callback = log_callback
@@ -99,6 +102,8 @@ class OBSImageUtil(object):
         self.image_metadata_name = None
         self.image_checksum = None
         self.conditions = conditions
+        self.filter_licenses = filter_licenses
+        self.filter_packages = filter_packages
 
         if checksum_extension:
             self.checksum_extensions = [checksum_extension]
@@ -279,6 +284,19 @@ class OBSImageUtil(object):
         if not self._image_conditions_complied():
             raise OBSImageConditionsException('Image conditions not met')
 
+    def check_license_conditions(self):
+        for package, pkg_data in self.image_status['packages'].items():
+            if pkg_data.license in self.filter_licenses:
+                raise OBSImageConditionsException(
+                    'Package(s) found in the image that match '
+                    'dis-allowed licenses. A full list can be provided'
+                    ' using "obs-img-utils packages list '
+                    '--filter-licenses"'.format(
+                        name=package,
+                        license=pkg_data.license
+                    )
+                )
+
     def _wait_on_image_conditions(self):
         start = time.time()
         end = start + self.conditions_wait_time
@@ -286,6 +304,8 @@ class OBSImageUtil(object):
         while True:
             try:
                 self.check_image_conditions()
+                self.check_license_conditions()
+                self.check_invalid_packages()
                 break
             except OBSImageConditionsException as error:
                 if time.time() < end:
@@ -381,10 +401,17 @@ class OBSImageUtil(object):
                 package_digest.update(package.encode())
                 package_info = package.split('|')
                 package_name = package_info[0]
+
+                if len(package_info) == 7:
+                    package_license = package_info[6].strip()
+                else:
+                    package_license = 'unknown'
+
                 package_result = package_type(
                     version=package_info[2],
                     release=package_info[3],
                     arch=package_info[4],
+                    license=package_license,
                     checksum=package_digest.hexdigest()
                 )
                 result_packages[package_name] = package_result
@@ -423,6 +450,18 @@ class OBSImageUtil(object):
             package_data.version,
             package_name
         )
+
+    def check_invalid_packages(self):
+        for package_name in self.filter_packages:
+            if fnmatch.filter(self.image_status['packages'], package_name):
+                raise OBSImageConditionsException(
+                    'Package(s) matching {name} found in image. '
+                    'A full list of packages can be provided using '
+                    ' "obs-img-utils packages list '
+                    '--filter-packages"'.format(
+                        name=package_name
+                    )
+                )
 
     def _check_version_and_build_condition(
         self,

--- a/obs_img_utils/api.py
+++ b/obs_img_utils/api.py
@@ -397,14 +397,17 @@ class OBSImageUtil(object):
         result_packages = {}
         with open(packages_file.name) as packages:
             for package in packages.readlines():
+                # Packages file format:
+                # name|{empty}|version|release|arch|uri|license
                 package_digest = hashlib.md5()
                 package_digest.update(package.encode())
                 package_info = package.split('|')
                 package_name = package_info[0]
 
-                if len(package_info) == 7:
+                try:
+                    # license is optional in packages file
                     package_license = package_info[6].strip()
-                else:
+                except IndexError:
                     package_license = 'unknown'
 
                 package_result = package_type(

--- a/obs_img_utils/utils.py
+++ b/obs_img_utils/utils.py
@@ -24,6 +24,7 @@ import os
 import sys
 import time
 import yaml
+import fnmatch
 
 from collections import ChainMap, namedtuple
 from contextlib import contextmanager, suppress
@@ -329,3 +330,66 @@ def get_checksum_from_file(checksum_file):
         expected_checksum = lines[0].strip().split()[0]
 
     return expected_checksum
+
+
+def license_repl():
+    """
+    Query and accept input for license types.
+    """
+    licenses = []
+    while True:
+        if click.confirm('Add another license?'):
+            license_name = click.prompt(
+                'Enter the license name (GPL-2.0-only)',
+                type=str
+            )
+            licenses.append(license_name)
+        else:
+            break
+
+    return licenses
+
+
+def packages_repl():
+    """
+    Query and accept input for invalid package names.
+    """
+    packages = []
+    while True:
+        if click.confirm('Add another package?'):
+            package_name = click.prompt(
+                'Enter the package name or wildcard (*-mini)',
+                type=str
+            )
+            packages.append(package_name)
+        else:
+            break
+
+    return packages
+
+
+def filter_packages_by_licenses(packages_metadata, licenses):
+    """
+    Returned a filtered dictionary of packages that matches the licenses.
+    """
+    matching_packages = {}
+    for package, pkg_data in packages_metadata.items():
+        if pkg_data.license in licenses:
+            matching_packages[package] = pkg_data
+
+    return matching_packages
+
+
+def filter_packages_by_name(packages_metadata, package_name):
+    """
+    Returned a filtered dictionary of packages that matches the package names.
+    """
+    matching_packages = {}
+
+    packages = packages_metadata.keys()
+    matching_names = fnmatch.filter(packages, package_name)
+
+    for name in matching_names:
+        matching_packages[name] = packages_metadata[name]
+
+    return matching_packages

--- a/tests/data/packages
+++ b/tests/data/packages
@@ -1,1 +1,1 @@
-apparmor-parser|(none)|2.12.2|lp150.6.14.1|x86_64|obs://build.opensuse.org/openSUSE:Maintenance:9971/openSUSE_Leap_15.0_Update/0ab7689366a67bad43f66b388f34f31e-apparmor.openSUSE_Leap_15.0_Update
+apparmor-parser|(none)|2.12.2|lp150.6.14.1|x86_64|obs://build.opensuse.org/openSUSE:Maintenance:9971/openSUSE_Leap_15.0_Update/0ab7689366a67bad43f66b388f34f31e-apparmor.openSUSE_Leap_15.0_Update|MIT

--- a/tests/test_obs_img_utils_api.py
+++ b/tests/test_obs_img_utils_api.py
@@ -68,6 +68,7 @@ class TestAPI(object):
             version='0.2',
             release='1.1',
             arch='x86_64',
+            license='MIT',
             checksum='ABC1234567890'
         )
         packages = {'test': package}

--- a/tests/test_obs_img_utils_utils.py
+++ b/tests/test_obs_img_utils_utils.py
@@ -57,4 +57,4 @@ def test_get_checksum_from_file():
 def test_get_hash_from_image():
     output = get_hash_from_image('tests/data/packages')
     assert output.hexdigest() == \
-        '0fe51e551cbfe0b217a4ab128cd34b26eb92add6ab1c8033ba2dcd831c4e5b52'
+        'f71d1050f3b3b1c02b3f420866e4539c9ab482d9a0497de4c40b9d3afbc99b55'


### PR DESCRIPTION
Provide an option to fail image download if a package, or license
exists in the given image.

The list packages option can now also be filtered by licenses and
package name.

The disallow package name can use the wildcard (*) to match a
name expression. For example *-mini can be filtered to prevent
mini packages in image.