### PR TITLE
Fix the web scraping to get filenames from repos for the new OBS web interface

### DIFF
--- a/obs_img_utils/web_content.py
+++ b/obs_img_utils/web_content.py
@@ -46,7 +46,7 @@ class WebContent(object):
             index_list = self._manage_fetch_index_list(
                 base_name,
                 href_prefix='./'
-                )
+            )
         return index_list
 
     def fetch_to_dir(

--- a/tests/data/index_new.html
+++ b/tests/data/index_new.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of images</title>
+ </head>
+ <body>
+<h1>Index of images</h1>
+<pre><img src="/icons/blank.gif" alt="Icon "> <a href="?C=N;O=D">Name</a>                                                                               <a href="?C=M;O=A">Last modified</a>      <a href="?C=S;O=A">Size</a>  <a href="?C=D;O=A">Description</a><hr><img src="/icons/back.gif" alt="[PARENTDIR]"> <a href="">Parent Directory</a>                                                                                        -
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="./SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.packages">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.packages</a>                              2020-05-11 19:00  112K
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="./SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz</a>                           2020-05-11 19:00  333M
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="./SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256</a>                    2020-05-11 19:00  122
+<img src="/icons/text.gif" alt="[TXT]"> <a href="./SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256.asc">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256.asc</a>                2020-05-11 19:00  481
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="./SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.packages">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.packages</a>                                      2020-04-20 11:44   93K
+<img src="/icons/compressed.gif" alt="[   ]"> <a href="./SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz</a>                                        2020-04-20 11:44  447M
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="./SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256</a>                                 2020-04-20 11:44  109
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="./SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256.asc">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256.asc</a>                                 2020-04-20 11:44  109
+<hr></pre>
+</body></html>

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -34,6 +34,7 @@ def test_fetch_to_dir(mock_url_retrieve):
         ['packages'])
     assert name == 'tests/data/SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.packages'
 
+
 @patch('obs_img_utils.web_content.urlretrieve')
 def test_fetch_to_dir_new_web(mock_url_retrieve):
     path = os.path.abspath('tests/data/index_new.html')

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -33,3 +33,14 @@ def test_fetch_to_dir(mock_url_retrieve):
         'tests/data',
         ['packages'])
     assert name == 'tests/data/SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.packages'
+
+@patch('obs_img_utils.web_content.urlretrieve')
+def test_fetch_to_dir_new_web(mock_url_retrieve):
+    path = os.path.abspath('tests/data/index_new.html')
+    wc = WebContent('file://{0}'.format(path))
+    name = wc.fetch_to_dir(
+        'SLES15-SP1-GCE',
+        '^SLES15-SP1-GCE\\.x86_64-(\\d+\\.\\d+\\.\\d+)-Build(.*)',
+        'tests/data',
+        ['packages'])
+    assert name == 'tests/data/SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.packages'


### PR DESCRIPTION
# Issue

The web scraping in obs-img-utils relies on a `xpath` filter expression to get the links in the repository web page that match the image base name we're working with.

The current version of Open Build Service includes a modification in the links (`href` parameter gets prefixed with a './') thus the scraper returns an empty list of files ([example](https://download.suse.de/ibs/home:/amunoz:/playground/images/)).

# Change
This change modifies the scraping function without breaking backwards compatibility. In case the original scraping returns the empty list, it attempts to do the scraping with the './' prefix. The prefix is removed from the obtained matching list not to impact later logic in the code.

New test has been included to test the behavior.
