### PR TITLE
Include an --output option to packages subcommands to allow the user select output format

### DIFF
--- a/obs_img_utils/cli.py
+++ b/obs_img_utils/cli.py
@@ -267,9 +267,22 @@ def packages():
     help='The output format (text|json)',
     default='text'
 )
+@click.option(
+    '--no-headers',
+    is_flag=True,
+    help='Do not print headers in text output',
+    default=False
+)
 @add_options(shared_options)
 @click.pass_context
-def list_packages(context, filter_licenses, filter_packages, output, **kwargs):
+def list_packages(
+        context,
+        filter_licenses,
+        filter_packages,
+        output,
+        no_headers,
+        **kwargs
+):
     """
     Return a list of packages for the given image name.
     """
@@ -323,7 +336,8 @@ def list_packages(context, filter_licenses, filter_packages, output, **kwargs):
     else:
         echo_packages_text(
             packages_metadata,
-            no_color=config_data.no_color
+            no_color=config_data.no_color,
+            no_headers=no_headers
         )
 
 
@@ -340,9 +354,15 @@ def list_packages(context, filter_licenses, filter_packages, output, **kwargs):
     help='The output format (text|json)',
     default='text'
 )
+@click.option(
+    '--no-headers',
+    is_flag=True,
+    help='Do not print headers in text output',
+    default=False
+)
 @add_options(shared_options)
 @click.pass_context
-def show(context, package_name, output, **kwargs):
+def show(context, package_name, output, no_headers, **kwargs):
     """
     Return information for the provided package name in the given image.
     """
@@ -372,7 +392,8 @@ def show(context, package_name, output, **kwargs):
         echo_package_text(
             package_name,
             packages_metadata,
-            no_color=config_data.no_color
+            no_color=config_data.no_color,
+            no_headers=no_headers
         )
 
 

--- a/obs_img_utils/cli.py
+++ b/obs_img_utils/cli.py
@@ -263,7 +263,7 @@ def packages():
 )
 @click.option(
     '--output',
-    type=click.Choice(["text", "json"]),
+    type=click.Choice(['text', 'json']),
     help='The output format (text|json)',
     default='text'
 )

--- a/obs_img_utils/cli.py
+++ b/obs_img_utils/cli.py
@@ -24,8 +24,10 @@ from obs_img_utils.utils import (
     click_progress_callback,
     conditions_repl,
     handle_errors,
-    echo_package,
-    echo_packages,
+    echo_package_json,
+    echo_package_text,
+    echo_packages_json,
+    echo_packages_text,
     get_logger,
     process_shared_options,
     license_repl,
@@ -259,9 +261,15 @@ def packages():
     is_flag=True,
     help='Invoke packages REPL to specify package name filters'
 )
+@click.option(
+    '--output',
+    type=click.Choice(["text", "json"]),
+    help='The output format (text|json)',
+    default='text'
+)
 @add_options(shared_options)
 @click.pass_context
-def list_packages(context, filter_licenses, filter_packages, **kwargs):
+def list_packages(context, filter_licenses, filter_packages, output, **kwargs):
     """
     Return a list of packages for the given image name.
     """
@@ -307,10 +315,13 @@ def list_packages(context, filter_licenses, filter_packages, **kwargs):
 
         packages_metadata = matching_packages
 
-    if not packages_metadata:
-        click.echo('No packages found matching criteria.')
+    if output == 'json':
+        echo_packages_json(
+            packages_metadata,
+            no_color=config_data.no_color
+        )
     else:
-        echo_packages(
+        echo_packages_text(
             packages_metadata,
             no_color=config_data.no_color
         )
@@ -323,9 +334,15 @@ def list_packages(context, filter_licenses, filter_packages, **kwargs):
     required=True,
     help='Name of the package.'
 )
+@click.option(
+    '--output',
+    type=click.Choice(["text", "json"]),
+    help='The output format (text|json)',
+    default='text'
+)
 @add_options(shared_options)
 @click.pass_context
-def show(context, package_name, **kwargs):
+def show(context, package_name, output, **kwargs):
     """
     Return information for the provided package name in the given image.
     """
@@ -345,11 +362,18 @@ def show(context, package_name, **kwargs):
         )
         packages_metadata = downloader.get_image_packages_metadata()
 
-    echo_package(
-        package_name,
-        packages_metadata,
-        no_color=config_data.no_color
-    )
+    if output == 'json':
+        echo_package_json(
+            package_name,
+            packages_metadata,
+            no_color=config_data.no_color
+        )
+    else:
+        echo_package_text(
+            package_name,
+            packages_metadata,
+            no_color=config_data.no_color
+        )
 
 
 main.add_command(download)

--- a/obs_img_utils/utils.py
+++ b/obs_img_utils/utils.py
@@ -29,6 +29,7 @@ import fnmatch
 from collections import ChainMap, namedtuple
 from contextlib import contextmanager, suppress
 from functools import wraps
+from tabulate import tabulate
 
 module = sys.modules[__name__]
 
@@ -57,6 +58,7 @@ defaults = {
     'checksum_extension': None,
     'extension': None,
     'signature_extension': None,
+    'output': 'text'
 }
 
 img_downloader_config = namedtuple(
@@ -238,11 +240,12 @@ def style_string(message, no_color, fg='yellow'):
         return click.style(message, fg=fg)
 
 
-def echo_package(name, data, no_color):
+def echo_package_text(name, data, no_color):
     """
     Echoes package info to terminal based on name.
     """
     try:
+        headers = ["name", "version", "release", "arch", "license", "checksum"]
         package_info = data[name]
     except KeyError:
         echo_style(
@@ -250,6 +253,33 @@ def echo_package(name, data, no_color):
             no_color,
             fg='red'
         )
+    else:
+        values = []
+        values.append([*package_info._asdict().values()])
+        click.echo(
+            style_string(
+                tabulate(values, headers),
+                no_color,
+                fg='green'
+            )
+        )
+
+
+def echo_package_json(name, data, no_color):
+    """
+    Echoes package info to terminal based on name in json format.
+    """
+    try:
+        package_info = data[name]
+    except KeyError:
+        click.echo(
+            style_string(
+                json.dumps({}),
+                no_color,
+                fg='red'
+            )
+        )
+
     else:
         click.echo(
             style_string(
@@ -260,9 +290,26 @@ def echo_package(name, data, no_color):
         )
 
 
-def echo_packages(data, no_color):
+def echo_packages_text(data, no_color):
     """
-    Echoes list of package info to terminal.
+    Echoes list of package info to terminal in text format.
+    """
+    headers = ["name", "version", "release", "arch", "license", "checksum"]
+
+    values = []
+    for name, inner in data.items():
+        values.append([*inner._asdict().values()])
+
+    click.echo(
+        style_string(
+            tabulate(values, headers),
+            no_color,
+            fg='green')
+    )
+
+def echo_packages_json(data, no_color):
+    """
+    Echoes list of package info to terminal in json format.
     """
     packages = {}
     for name, info in data.items():

--- a/obs_img_utils/utils.py
+++ b/obs_img_utils/utils.py
@@ -307,6 +307,7 @@ def echo_packages_text(data, no_color):
             fg='green')
     )
 
+
 def echo_packages_json(data, no_color):
     """
     Echoes list of package info to terminal in json format.

--- a/obs_img_utils/utils.py
+++ b/obs_img_utils/utils.py
@@ -29,7 +29,6 @@ import fnmatch
 from collections import ChainMap, namedtuple
 from contextlib import contextmanager, suppress
 from functools import wraps
-from tabulate import tabulate
 
 module = sys.modules[__name__]
 
@@ -240,7 +239,7 @@ def style_string(message, no_color, fg='yellow'):
         return click.style(message, fg=fg)
 
 
-def echo_package_text(name, data, no_color):
+def echo_package_text(name, data, no_color, no_headers=False):
     """
     Echoes package info to terminal based on name.
     """
@@ -258,11 +257,79 @@ def echo_package_text(name, data, no_color):
         values.append([*package_info._asdict().values()])
         click.echo(
             style_string(
-                tabulate(values, headers),
+                _get_text_table(values, headers, no_headers),
                 no_color,
                 fg='green'
             )
         )
+
+
+def _get_text_table(data, headers, no_headers=False):
+    widths = _get_text_column_widths(headers, data)
+
+    if no_headers is False:
+        table = _get_headersline(headers, widths) + "\n"
+        table += _get_separatorline(widths) + "\n"
+    for d in data:
+        table += _get_dataline(d, widths)
+        table += "\n"
+    return table
+
+
+def _get_headersline(headers, widths):
+    """
+    Function to get the headers line for text output formatting
+    """
+    line = ""
+    for idx, value in enumerate(headers):
+        line += _padright(widths[idx], value)
+        line += " "
+    return line
+
+
+def _get_separatorline(widths):
+    """
+    Function to get the separator line for text output formatting
+    """
+    line = ""
+    for width in widths:
+        line += "-" * width
+        line += " "
+    return line
+
+
+def _get_dataline(data, widths):
+    """
+    Function to get the a line with data for text output formatting
+    """
+    line = ""
+    for idx, s in enumerate(data):
+        line += _padright(widths[idx], str(s))
+        line += " "
+    return line
+
+
+def _padright(width, s):
+    """
+    Function to get a right padded string of width s
+    """
+    fmt = "{0:<%ds}" % width
+    return fmt.format(s)
+
+
+def _get_text_column_widths(headers, values):
+    """
+    Function to get the column with required for text formatting
+    """
+    widths = []
+    for header in headers:
+        widths.append(len(str(header)))
+
+    for value in values:
+        for idx, val in enumerate(value):
+            if len(str(val)) > widths[idx]:
+                widths[idx] = len(str(val))
+    return widths
 
 
 def echo_package_json(name, data, no_color):
@@ -290,7 +357,7 @@ def echo_package_json(name, data, no_color):
         )
 
 
-def echo_packages_text(data, no_color):
+def echo_packages_text(data, no_color, no_headers=False):
     """
     Echoes list of package info to terminal in text format.
     """
@@ -302,7 +369,7 @@ def echo_packages_text(data, no_color):
 
     click.echo(
         style_string(
-            tabulate(values, headers),
+            _get_text_table(values, headers, no_headers),
             no_color,
             fg='green')
     )

--- a/obs_img_utils/utils.py
+++ b/obs_img_utils/utils.py
@@ -270,8 +270,8 @@ def _get_text_table(data, headers, no_headers=False):
     if no_headers is False:
         table = _get_headersline(headers, widths) + "\n"
         table += _get_separatorline(widths) + "\n"
-    for d in data:
-        table += _get_dataline(d, widths)
+    for item in data:
+        table += _get_dataline(item, widths)
         table += "\n"
     return table
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click
 lxml
 pyyaml
 xmltodict
+tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ click
 lxml
 pyyaml
 xmltodict
-tabulate

--- a/tests/test_obs_img_utils_cli.py
+++ b/tests/test_obs_img_utils_cli.py
@@ -81,7 +81,8 @@ def test_packages_list(mock_fetch_file, mock_url_open):
             '--download-url',
             'https://provo-mirror.opensuse.org/repositories/'
             'Cloud:/Images:/Leap_15.0/images/',
-            '--target-dir', 'tests/data'
+            '--target-dir', 'tests/data',
+            "--output", "json"
         ],
         input='y\n'
               'MIT\n'
@@ -127,7 +128,8 @@ def test_filter_packages_list(
             '--download-url',
             'https://provo-mirror.opensuse.org/repositories/'
             'Cloud:/Images:/Leap_15.0/images/',
-            '--target-dir', 'tests/data'
+            '--target-dir', 'tests/data',
+            "--output", "json"
         ],
         input='y\n'
               'apparmor-parser\n'
@@ -173,7 +175,8 @@ def test_packages_show(
             'https://provo-mirror.opensuse.org/repositories/'
             'Cloud:/Images:/Leap_15.0/images/',
             '--target-dir', 'tests/data',
-            '--package-name', 'apparmor-parser'
+            '--package-name', 'apparmor-parser',
+            '--output', 'json'
         ]
     )
     assert result.exit_code == 0

--- a/tests/test_obs_img_utils_cli.py
+++ b/tests/test_obs_img_utils_cli.py
@@ -82,7 +82,7 @@ def test_packages_list(mock_fetch_file, mock_url_open):
             'https://provo-mirror.opensuse.org/repositories/'
             'Cloud:/Images:/Leap_15.0/images/',
             '--target-dir', 'tests/data',
-            "--output", "json"
+            '--output', 'json'
         ],
         input='y\n'
               'MIT\n'

--- a/tests/test_obs_img_utils_utils.py
+++ b/tests/test_obs_img_utils_utils.py
@@ -23,7 +23,8 @@ from unittest.mock import patch, MagicMock
 
 from obs_img_utils.utils import (
     retry,
-    echo_package,
+    echo_package_json,
+    echo_package_text,
     get_checksum_from_file,
     get_hash_from_image
 )
@@ -40,8 +41,12 @@ def test_retry_decorator(mock_time):
         fake_method()
 
 
-def test_echo_package():
-    echo_package('package', {}, False)
+def test_echo_package_text():
+    echo_package_text('package', {}, False)
+
+
+def test_echo_package_json():
+    echo_package_json('package', {}, False)
 
 
 def test_get_checksum_from_file():

--- a/tests/test_obs_img_utils_utils.py
+++ b/tests/test_obs_img_utils_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC, All rights reserved.
+# Copyright (c) 2022 SUSE LLC, All rights reserved.
 #
 # This file is part of obs-img-utils. obs-img-utils provides
 # an api and command line utilities for images in OBS.
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import collections
 import io
 
 from contextlib import suppress
@@ -25,8 +26,9 @@ from obs_img_utils.utils import (
     retry,
     echo_package_json,
     echo_package_text,
+    echo_packages_text,
     get_checksum_from_file,
-    get_hash_from_image
+    get_hash_from_image,
 )
 
 
@@ -41,11 +43,11 @@ def test_retry_decorator(mock_time):
         fake_method()
 
 
-def test_echo_package_text():
+def test_echo_package_text_empty():
     echo_package_text('package', {}, False)
 
 
-def test_echo_package_json():
+def test_echo_package_json_empty():
     echo_package_json('package', {}, False)
 
 
@@ -69,3 +71,79 @@ def test_get_hash_from_image():
     )
     assert output.hexdigest() == \
         'f71d1050f3b3b1c02b3f420866e4539c9ab482d9a0497de4c40b9d3afbc99b55'
+
+
+def test_echo_packages_text(capsys):
+    headers = ["name", "version", "release", "arch", "license", "checksum"]
+    Pkg_info = collections.namedtuple("Pkg_info", headers)
+    pkg1 = Pkg_info(
+        "zypper-lifecycle-plugin",
+        "0.6.1601367426.843fe7a",
+        "1.60",
+        "x86_64",
+        "GPL-2.0",
+        "332dd2f09402e8e411184f7b27ef469c"
+    )
+    data = {}
+    data["zypper-lifecycle-plugin"] = pkg1
+
+    pkg2 = Pkg_info(
+            "zypper",
+            "1.14.55",
+            "150400.3.6.1",
+            "x86_64",
+            "GPL-2.0-or-later",
+            "595cbdc5262afb29ad1baeb155635325"
+    )
+    data["zypper"] = pkg2
+
+    echo_packages_text(data, True, no_headers=False)
+
+    captured = capsys.readouterr()
+
+    expected_header = "name                    version                release      arch   license          checksum                        "   # noqa: E501
+    expected_separator = "----------------------- ---------------------- ------------ ------ ---------------- --------------------------------"   # noqa: E501
+    expected_data1 = "zypper-lifecycle-plugin 0.6.1601367426.843fe7a 1.60         x86_64 GPL-2.0          332dd2f09402e8e411184f7b27ef469c"   # noqa: E501
+    expected_data2 = "zypper                  1.14.55                150400.3.6.1 x86_64 GPL-2.0-or-later 595cbdc5262afb29ad1baeb155635325"   # noqa: E501
+
+    assert expected_header in captured.out
+    assert expected_separator in captured.out
+    assert expected_data1 in captured.out
+    assert expected_data2 in captured.out
+
+
+def test_echo_package_text(capsys):
+    headers = ["name", "version", "release", "arch", "license", "checksum"]
+    Pkg_info = collections.namedtuple("Pkg_info", headers)
+    pkg1 = Pkg_info(
+        "zypper-lifecycle-plugin",
+        "0.6.1601367426.843fe7a",
+        "1.60",
+        "x86_64",
+        "GPL-2.0",
+        "332dd2f09402e8e411184f7b27ef469c"
+    )
+    data = {}
+    data["zypper-lifecycle-plugin"] = pkg1
+
+    pkg2 = Pkg_info(
+            "zypper",
+            "1.14.55",
+            "150400.3.6.1",
+            "x86_64",
+            "GPL-2.0-or-later",
+            "595cbdc5262afb29ad1baeb155635325"
+    )
+    data["zypper"] = pkg2
+
+    echo_package_text("zypper", data, True, no_headers=False)
+
+    captured = capsys.readouterr()
+
+    expected_header = "name   version release      arch   license          checksum                        "   # noqa: E501
+    expected_separator = "------ ------- ------------ ------ ---------------- --------------------------------"   # noqa: E501
+    expected_data1 = "zypper 1.14.55 150400.3.6.1 x86_64 GPL-2.0-or-later 595cbdc5262afb29ad1baeb155635325"   # noqa: E501
+
+    assert expected_header in captured.out
+    assert expected_separator in captured.out
+    assert expected_data1 in captured.out


### PR DESCRIPTION
[Issue 8](https://github.com/SUSE-Enceladus/obs-img-utils/issues/8)

- Includes the --output format (text|json) to decide the output format.
- The tabulate library has been included as new dependency (supported with python >=3.6). Could be removed and build the output 'manually' if required.
- Not very much gain for now when using filters (as they show interactive menus always), but will tackle that later.
- Default output is text (which is a change from current json by default). We'll have to remember when bumping the version...

## Tests
```sh
> obs-img-utils packages show --download-url https://download.suse.de/ibs/home:/amunoz:/playground/images/ --image-name SLES15-SP4-BYOS --profile EC2 --no-color --package-name wicked22 --output json
{}

> obs-img-utils packages show --download-url https://download.suse.de/ibs/home:/amunoz:/playground/images/ --image-name SLES15-SP4-BYOS --profile EC2 --no-color --package-name wicked22 --output text
Package with name: wicked22, not in image.

> obs-img-utils packages list --download-url https://download.suse.de/ibs/home:/amunoz:/playground/images/ --image-name SLES15-SP4-BYOS --profile EC2 --no-color | head
name                                    version                        release           arch    license                                                                              checksum
--------------------------------------  -----------------------------  ----------------  ------  -----------------------------------------------------------------------------------  --------------------------------
aaa_base-extras                         84.87+git20180409.04c9dae      3.57.1            x86_64  GPL-2.0+                                                                             722c4fee5939b558f7304ffb493e2db4
aaa_base                                84.87+git20180409.04c9dae      3.57.1            x86_64  GPL-2.0+                                                                             bf30b090014a70ef3f117265d1f35f06
amazon-ssm-agent                        3.1.1260.0                     150000.5.9.2      x86_64  Apache-2.0                                                                           d73d3ba74356746c3571ec7f5d256e89
apparmor-parser                         3.0.4                          150400.3.4        x86_64  GPL-2.0-or-later                                                                     50c7fdd404fb837f7fb16ece6076d114
at-spi2-core                            2.42.0                         150400.2.7        x86_64  LGPL-2.1-or-later                                                                    e6c01873e7cb0603d280955e195a4d34
attr                                    2.4.47                         2.19              x86_64  GPL-2.0-or-later AND LGPL-2.1-or-later                                               d570700c151fd10296de1cb6bca77f70
at                                      3.2.2                          150400.4.3.10     x86_64  GPL-2.0-or-later                                                                     40c02b5d7183994781dfb64006aa3675
audit                                   3.0.6                          150400.4.3.1      x86_64  LGPL-2.1-or-later                                                                    abb7431e91a46e3f9025f4dc763bd80e

> obs-img-utils packages list --download-url https://download.suse.de/ibs/home:/amunoz:/playground/images/ --image-name SLES15-SP4-BYOS --profile EC2 --no-color | head --output json | head
head: unrecognized option '--output'
Try 'head --help' for more information.

> obs-img-utils packages list --download-url https://download.suse.de/ibs/home:/amunoz:/playground/images/ --image-name SLES15-SP4-BYOS --profile EC2 --no-color --output json| head
{
  "aaa_base-extras": {
    "name": "aaa_base-extras",
    "version": "84.87+git20180409.04c9dae",
    "release": "3.57.1",
    "arch": "x86_64",
    "license": "GPL-2.0+",
    "checksum": "722c4fee5939b558f7304ffb493e2db4"
  },
  "aaa_base": {

```



