### PR TITLE
Choses the highest version-release combination as base_name if base_name is not set

### DIFF
--- a/tests/data/index_name_picker.html
+++ b/tests/data/index_name_picker.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+ <head>
+  <title>Index of images</title>
+ </head>
+ <body>
+<h1>Index of images</h1>
+<pre><img src="/icons/blank.gif" alt="Icon "> <a href="?C=N;O=D">Name</a>                                                                               <a href="?C=M;O=A">Last modified</a>      <a href="?C=S;O=A">Size</a>  <a href="?C=D;O=A">Description</a><hr><img src="/icons/back.gif" alt="[PARENTDIR]"> <a href="">Parent Directory</a>                                                                                        -
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.packages">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.packages</a>                              2020-05-11 19:00  112K
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz</a>                           2020-05-11 19:00  333M
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256</a>                    2020-05-11 19:00  122
+<img src="/icons/text.gif" alt="[TXT]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256.asc">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build1.26.vhdfixed.xz.sha256.asc</a>                2020-05-11 19:00  481
+
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.packages">SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.packages</a>                              2020-05-11 19:00  112K
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.vhdfixed.xz">SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.vhdfixed.xz</a>                           2020-05-11 19:00  333M
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.vhdfixed.xz.sha256">SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.vhdfixed.xz.sha256</a>                    2020-05-11 19:00  122
+<img src="/icons/text.gif" alt="[TXT]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.vhdfixed.xz.sha256.asc">SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.vhdfixed.xz.sha256.asc</a>                2020-05-11 19:00  481
+
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.packages">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.packages</a>                              2020-05-11 19:00  112K
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.vhdfixed.xz">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.vhdfixed.xz</a>                           2020-05-11 19:00  333M
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.vhdfixed.xz.sha256">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.vhdfixed.xz.sha256</a>                    2020-05-11 19:00  122
+<img src="/icons/text.gif" alt="[TXT]"> <a href="SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.vhdfixed.xz.sha256.asc">SLES15-SP1-Azure-BYOS.x86_64-1.0.3-Build3.26.vhdfixed.xz.sha256.asc</a>                2020-05-11 19:00  481
+
+
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.packages">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.packages</a>                                      2020-04-20 11:44   93K
+<img src="/icons/compressed.gif" alt="[   ]"> <a href="SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz</a>                                        2020-04-20 11:44  447M
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256</a>                                 2020-04-20 11:44  109
+<img src="/icons/unknown.gif" alt="[   ]"> <a href="SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256.asc">SLES15-SP1-GCE.x86_64-1.0.2-Build1.6.tar.gz.sha256.asc</a>                                 2020-04-20 11:44  109
+<hr></pre>
+</body></html>

--- a/tests/test_web_content.py
+++ b/tests/test_web_content.py
@@ -70,3 +70,23 @@ def test_fetch_to_dir_json(mock_urlopen, mock_urlretrieve):
         'tests/data',
         ['packages'])
     assert name == 'tests/data/SLES15-SP2-GCE.x86_64-1.0.2-Build1.6.packages'
+
+
+@patch('obs_img_utils.web_content.urlretrieve')
+@patch('obs_img_utils.web_content.urlopen')
+def test_fetch_file_name(mock_urlopen, mock_urlretrieve):
+    with open('tests/data/index_name_picker.html') as f:
+        first_response = f.read()
+
+    mock_urlopen.return_value.read.side_effect = [
+        first_response,
+    ]
+
+    path = os.path.abspath('tests/data/index_name_picker.html')
+    wc = WebContent('file://{0}'.format(path))
+    name, extension = wc.fetch_file_name(
+        'SLES15-SP1-Azure-BYOS.x86_64',
+        '^SLES15-SP1-Azure-BYOS\\.x86_64-(\\d+\\.\\d+\\.\\d+)-Build(.*)',
+        ['vhdfixed.xz'])
+    assert name == 'SLES15-SP1-Azure-BYOS.x86_64-1.2.3-Build1.22.'
+    assert extension == 'vhdfixed.xz'


### PR DESCRIPTION
I tripped over this issue with the CVE Release automation.

For the CVE automation case, we look directly in the "Released" repo with the regex to match the image filename (to get the `.packages` file for example).
Previously, the obs_image_utils was getting the first regex match. The problem is that in the "Released" repo, all the previous versions are there, and we were picking the `.packages` list for the first match instead of the latest one.

Changed the logics to get all matches for the regex and then selecting the highest version-release combination.

In the case of brewmaster I think it picks up the expected selection, because there's just one  version (the latest one) in the `nightly` project, and that gets into brewmaster as a condition over the image to be released.
