### PR TITLE
Don't fail on missing metadata

### DIFF
--- a/obs_img_utils/api.py
+++ b/obs_img_utils/api.py
@@ -411,7 +411,15 @@ class OBSImageUtil(object):
         try:
             result_packages = self.parse_report_file()
         except DownloadMetadataFileExceptionOBS:
-            result_packages = self.parse_packages_file()
+            try:
+                result_packages = self.parse_packages_file()
+            except DownloadMetadataFileExceptionOBS:
+                self.log_callback.warning(
+                    'No image metadata found: {0} and {1} unverifiable'.format(
+                        'package conditions',
+                        'buildtime constraints'
+                    )
+                )
 
         return result_packages
 

--- a/obs_img_utils/api.py
+++ b/obs_img_utils/api.py
@@ -407,19 +407,22 @@ class OBSImageUtil(object):
         self._image_release = version.obs_build
 
     @retry(DownloadMetadataFileExceptionOBS)
-    def get_image_packages_metadata(self):
+    def get_image_packages_metadata(self) -> dict:
+        has_error = None
+        result_packages = {}
         try:
             result_packages = self.parse_report_file()
         except DownloadMetadataFileExceptionOBS:
             try:
                 result_packages = self.parse_packages_file()
-            except DownloadMetadataFileExceptionOBS:
-                self.log_callback.warning(
-                    'No image metadata found: {0} and {1} unverifiable'.format(
-                        'package conditions',
-                        'buildtime constraints'
-                    )
-                )
+            except DownloadMetadataFileExceptionOBS as issue:
+                has_error = issue
+
+        if self.conditions and has_error:
+            self.log_callback.error(
+                f'Cannot verify {self.conditions} without metadata'
+            )
+            raise OBSImageConditionsException(has_error)
 
         return result_packages
 


### PR DESCRIPTION
The method get_image_packages_metadata looks up either a .report or a .packages file from the given download URI. The information if present is used in mash to check on package conditions and for the build time of the image. In case no metadata information is present the returned package dict is empty and the object instance stored build time stays at its initial 'unknown' value. Not raising an exception but sending a log warning has two effects on mash:

1. An unknown buildtime causes a download of the image in any case
2. An empty packages information causes the optionally given package based conditions in the mash job description to be not verifiable

On the positive side any URL just providing an image can then be consumed by mash with the mentioned restrictions. At the moment the scope of mash is limited to OBS build images and projects which has the "withreports" flags configured. Any other source location is not consumable by mash and this commit would allow to increase the scope for mash.