### PR TITLE
Rpm fns py36 compatible

### DIFF
--- a/obs_img_utils/rpm.py
+++ b/obs_img_utils/rpm.py
@@ -181,12 +181,12 @@ def compare_rpm_labels(a_label, b_label):
     return release_compare
 
 
-def isascii(string):
+def isascii(string_to_check):
     """
     Returns a boolean indicating if string provided is ascii or not.
     Python 3.6 compatible
     """
     try:
-        return string.isascii()
+        return string_to_check.isascii()
     except AttributeError:
-        return all([ord(c) < 128 for c in string])
+        return all([ord(c) < 128 for c in string_to_check])

--- a/obs_img_utils/rpm.py
+++ b/obs_img_utils/rpm.py
@@ -92,7 +92,7 @@ def _remove_non_alphanumeric_start(char_list):
         if (
             (
                 char_list[0].isalnum() and
-                char_list[0].isascii()
+                isascii(char_list[0])
             ) or
             char_list[0] == '~' or
             char_list[0] == '^'
@@ -179,3 +179,14 @@ def compare_rpm_labels(a_label, b_label):
         return version_compare
     release_compare = compare_version(a_release, b_release)
     return release_compare
+
+
+def isascii(string):
+    """
+    Returns a boolean indicating if string provided is ascii or not.
+    Python 3.6 compatible
+    """
+    try:
+        return string.isascii()
+    except AttributeError:
+        return all([ord(c) < 128 for c in string])


### PR DESCRIPTION

The `str.isascii()` function was included in python 3.7.

This PR contains the change to be able to use the rpm utils in a python 3.6 environment.

